### PR TITLE
Hardcoding the Tensorflow version in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow
+FROM tensorflow/tensorflow:0.12.1-gpu
 WORKDIR /root
 RUN add-apt-repository ppa:webupd8team/java && apt-get update
 RUN echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections && echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections


### PR DESCRIPTION
With the new tensorflow 1.0 your docker project is not working anymore. Adding to the docker file the TF version